### PR TITLE
package.json: use SPDX license identfier

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": {
         "name": "Edwin Xu"
     },
-    "license": "SEE LICENSE IN LICENSE.md",
+    "license": "MIT",
     "homepage": "https://github.com/edwinhuish/better-comments-next/blob/master/README.md",
     "repository": {
         "type": "git",


### PR DESCRIPTION
fixing package.json according to NPM docs and LICENSE, fixing npm warnings

this will also lead to the correct license be shown in extension marketplaces