### PR TITLE
Add support for `tailwindcss` language type

### DIFF
--- a/src/definition/modules/common.ts
+++ b/src/definition/modules/common.ts
@@ -179,6 +179,7 @@ function getDefaultComments(languageCode: string): vscode.CommentRule | undefine
     case 'verilog':
       return { lineComment: '//', blockComment: ['/*', '*/'] };
     case 'css':
+    case 'tailwindcss':
       return { blockComment: ['/*', '*/'] };
     case 'coffeescript':
     case 'dockerfile':


### PR DESCRIPTION
Tailwind CSS adds to the "vocabulary" of CSS without actually extending the syntax/grammar. For example, this is valid CSS when using Tailwind, but would fail for vanilla CSS:

```css
@import 'tailwindcss';

@theme {
    --color-*: initial;
    --color-debug-dark: palevioletred;
    --color-debug-light: lavenderblush;
}

@utility debug-light {
    @apply border-debug-dark bg-debug-light text-debug-darker border border-dashed;
}

@utility debug-dark {
    @apply border-debug-light bg-debug-dark border border-dashed;
}
```

Most people using Tailwind will install the [Tailwind extension](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) and then override the default CSS language mode in their `settings.json`:

```json
{
    "files.associations": {
        "*.css": "tailwindcss",
    }
}
```

I was hoping Better Comments Next could add support for Tailwind CSS comment coloring? I'm not sure if this change is all that's needed to accomplish that.