### PR TITLE
Add styling support for plain comments without tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ With this extension, you will be able to categorize your annotations into:
 * TODOs
 * Highlights
 * Commented out code can also be styled to make it clear the code shouldn't be there
+* Plain comments without tags can also be styled with custom colors and formatting
 * Any other comment styles you'd like can be specified in the settings
 
 ![Annotated code](static/better-comments.png)
@@ -43,6 +44,16 @@ Default setting as below:
   "better-comments.fullHighlight": false,
   // Strict mode of tag matching. Default true
   "better-comments.strict": true,
+  // Style for plain comments without tags
+  "better-comments.plainComment": {
+    "enabled": false,
+    "color": "#6A9955",
+    "strikethrough": false,
+    "underline": false,
+    "backgroundColor": "transparent",
+    "bold": false,
+    "italic": false
+  },
   // Custom languages comments configuration
   "better-comments.languages": [
     // {

--- a/package.json
+++ b/package.json
@@ -439,6 +439,49 @@
                     "type": "boolean",
                     "description": "Strict mode of tag. default true.",
                     "default": true
+                },
+                "better-comments.plainComment": {
+                    "type": "object",
+                    "description": "Style for plain comments without tags",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable plain comment styling"
+                        },
+                        "color": {
+                            "type": "string",
+                            "description": "Font color, eg: #6A9955"
+                        },
+                        "strikethrough": {
+                            "type": "boolean",
+                            "description": "Enable text strikethrough."
+                        },
+                        "underline": {
+                            "type": "boolean",
+                            "description": "Enable text underline."
+                        },
+                        "backgroundColor": {
+                            "type": "string",
+                            "description": "Background color, eg: transparent"
+                        },
+                        "bold": {
+                            "type": "boolean",
+                            "description": "Set text font style to bold."
+                        },
+                        "italic": {
+                            "type": "boolean",
+                            "description": "Set text font style to italic."
+                        }
+                    },
+                    "default": {
+                        "enabled": false,
+                        "color": "#6A9955",
+                        "strikethrough": false,
+                        "underline": false,
+                        "backgroundColor": "transparent",
+                        "bold": false,
+                        "italic": false
+                    }
                 }
             }
         }


### PR DESCRIPTION
I Added new plainComment configuration option to customize styling for untagged comments.

- Implemented decoration logic to style plain comments with configurable color, font style, and formatting
- Updated README to document new plain comment styling capabilities
- Added type definitions and interfaces for plain comment configuration
- Added plainCommentDecorationType handling in configuration management
- Modified comment processing to detect