### PR TITLE
Fix infinite loop problem in block and doc comments

### DIFF
--- a/src/handler/modules/common.ts
+++ b/src/handler/modules/common.ts
@@ -205,7 +205,7 @@ export class CommonHandler extends Handler {
           const tagName = m1.groups!.TAG.toLowerCase();
 
           // exec with remember last reg index, reset m2Exp avoid reg cache
-          const m2Exp = new RegExp(`(?<PRE>^|${SP}*)(?<MARK>${mark})(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gim');
+          const m2Exp = new RegExp(`(?<PRE>^|\r?\n|${SP}*)(?<MARK>${mark})(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gim');
 
           // Find decoration range
           let m2: RegExpExecArray | null;
@@ -517,7 +517,7 @@ export class CommonHandler extends Handler {
           const tagName = m1.groups!.TAG.toLowerCase();
 
           // exec with remember last reg index, reset m2Exp avoid reg cache
-          const m2Exp = new RegExp(`(?<PRE>${SP}*${pre}|^)(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gim');
+          const m2Exp = new RegExp(`(?<PRE>${SP}*${pre}|^|\r?\n)(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gim');
 
           // Find decoration range
           let m2: RegExpExecArray | null;


### PR DESCRIPTION
The regex used for parsing block and doc comments would fall into an infinite loop when the comment contained `\r\n`.
This fix ensures that `\r\n` is included in the PRE match group, allowing the parser to advance correctly and preventing the infinite loop.