### PR TITLE
feat: support wildcard and regex matching in tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ Default setting as below:
 
 ![Config strict: false](static/strict_false.png)
 
+### Wildcard / regex tags
+
+By default a `tag` is matched as a literal string. Two optional per-tag flags let a tag match dynamically:
+
+- **`"wildcard": true`** — interpret the tag as a glob pattern: `*` matches any run of characters, `?` matches any single character; every other character is matched literally.
+- **`"regex": true`** — interpret the tag as a raw JavaScript regular expression. Takes precedence over `wildcard`. Named capture groups are not allowed (they collide with internal matching groups), and an invalid pattern falls back to a literal match.
+
+Tags without either flag stay literal, so the default tags (including `*`, `?`, `!`, `//`) keep working exactly as before.
+
+```jsonc
+"better-comments.tags": [
+  {
+    // matches "// todo[FOO-123]: ..." — brackets are literal, "*" is the wildcard
+    "tag": "todo[*]",
+    "wildcard": true,
+    "color": "#FF8C00"
+  },
+  {
+    // matches "// @ticket: ..." via a raw regex
+    "tag": "@\\w+",
+    "regex": true,
+    "color": "#3498DB"
+  }
+]
+```
+
 ## Supported Languages
 
 **All languages supported:**

--- a/README.md
+++ b/README.md
@@ -160,25 +160,26 @@ Default setting as below:
 
 ### Wildcard / regex tags
 
-By default a `tag` is matched as a literal string. Two optional per-tag flags let a tag match dynamically:
+By default a `tag` is matched as a literal string. The optional per-tag `"tagMode"` field lets a tag match dynamically:
 
-- **`"wildcard": true`** — interpret the tag as a glob pattern: `*` matches any run of characters, `?` matches any single character; every other character is matched literally.
-- **`"regex": true`** — interpret the tag as a raw JavaScript regular expression. Takes precedence over `wildcard`. Named capture groups are not allowed (they collide with internal matching groups), and an invalid pattern falls back to a literal match.
+- **`"text"`** (default) — match the tag as a literal string.
+- **`"wildcard"`** — interpret the tag as a glob pattern: `*` matches any run of characters, `?` matches any single character; every other character is matched literally.
+- **`"regex"`** — interpret the tag as a raw JavaScript regular expression. Named capture groups are not allowed (they collide with internal matching groups), and an invalid pattern falls back to a literal match.
 
-Tags without either flag stay literal, so the default tags (including `*`, `?`, `!`, `//`) keep working exactly as before.
+Tags without `"tagMode"` stay literal, so the default tags (including `*`, `?`, `!`, `//`) keep working exactly as before.
 
 ```jsonc
 "better-comments.tags": [
   {
     // matches "// todo[FOO-123]: ..." — brackets are literal, "*" is the wildcard
     "tag": "todo[*]",
-    "wildcard": true,
+    "tagMode": "wildcard",
     "color": "#FF8C00"
   },
   {
     // matches "// @ticket: ..." via a raw regex
     "tag": "@\\w+",
-    "regex": true,
+    "tagMode": "regex",
     "color": "#3498DB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -182,6 +182,14 @@
                             "multiline": {
                                 "type": "boolean",
                                 "description": "Enable multiline comments decoration until reach blank line."
+                            },
+                            "wildcard": {
+                                "type": "boolean",
+                                "description": "Interpret the tag as a glob pattern: `*` matches any run of characters, `?` matches any single character. eg: `todo[*]` matches `todo[FOO-123]`."
+                            },
+                            "regex": {
+                                "type": "boolean",
+                                "description": "Interpret the tag as a raw JavaScript regular expression. Takes precedence over `wildcard`. Named capture groups are not allowed. eg: `@\\w+`."
                             }
                         }
                     },

--- a/package.json
+++ b/package.json
@@ -183,13 +183,15 @@
                                 "type": "boolean",
                                 "description": "Enable multiline comments decoration until reach blank line."
                             },
-                            "wildcard": {
-                                "type": "boolean",
-                                "description": "Interpret the tag as a glob pattern: `*` matches any run of characters, `?` matches any single character. eg: `todo[*]` matches `todo[FOO-123]`."
-                            },
-                            "regex": {
-                                "type": "boolean",
-                                "description": "Interpret the tag as a raw JavaScript regular expression. Takes precedence over `wildcard`. Named capture groups are not allowed. eg: `@\\w+`."
+                            "tagMode": {
+                                "type": "string",
+                                "enum": [
+                                    "text",
+                                    "wildcard",
+                                    "regex"
+                                ],
+                                "default": "text",
+                                "description": "Tag match mode: `text` (literal, default), `wildcard` (glob: `*` matches any run of characters, `?` matches any single character), or `regex` (raw JavaScript regular expression; named capture groups are not allowed). eg: `{ \"tag\": \"todo[*]\", \"tagMode\": \"wildcard\" }` matches `todo[FOO-123]`."
                             }
                         }
                     },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceConfiguration } from 'vscode';
-import { escape } from '@/utils/regex';
+import { compileGlob, compileRegex, escape } from '@/utils/regex';
 import * as vscode from 'vscode';
 
 export interface Tag {
@@ -11,6 +11,14 @@ export interface Tag {
   italic: boolean;
   backgroundColor: string;
   multiline: boolean;
+  /**
+   * Interpret the tag as a glob pattern (`*` = any run, `?` = any single char).
+   */
+  wildcard?: boolean;
+  /**
+   * Interpret the tag as a raw JavaScript regex. Takes precedence over `wildcard`.
+   */
+  regex?: boolean;
 }
 
 export interface TagFlatten extends Tag {
@@ -64,6 +72,7 @@ let tagDecorationTypes: Map<string, vscode.TextEditorDecorationType> | undefined
 let multilineTagsEscaped: string[] | undefined;
 let lineTagsEscaped: string[] | undefined;
 let allTagsEscaped: string[] | undefined;
+let tagMatchers: { key: string; test: RegExp }[] | undefined;
 
 export function refresh() {
   // if already set tagDecorationTypes, clear decoration for visible editors
@@ -82,6 +91,7 @@ export function refresh() {
   multilineTagsEscaped = undefined;
   lineTagsEscaped = undefined;
   allTagsEscaped = undefined;
+  tagMatchers = undefined;
 }
 
 /**
@@ -115,6 +125,20 @@ export function getConfigurationFlatten() {
 }
 
 /**
+ * Compile a tag name into a regex sub-pattern based on its matching flags.
+ * Precedence: regex > wildcard > literal.
+ */
+function compileTagPattern(tag: Tag, name: string): string {
+  if (tag.regex) {
+    return compileRegex(name);
+  }
+  if (tag.wildcard) {
+    return compileGlob(name);
+  }
+  return escape(name);
+}
+
+/**
  * Flatten config tags
  */
 function flattenTags(tags: Tag[]) {
@@ -123,7 +147,7 @@ function flattenTags(tags: Tag[]) {
     if (!Array.isArray(tag.tag)) {
       // ! add tag only tag name not empty
       if (tag.tag) {
-        flatTags.push({ ...tag, tagEscaped: escape(tag.tag) } as TagFlatten);
+        flatTags.push({ ...tag, tagEscaped: compileTagPattern(tag, tag.tag) } as TagFlatten);
       }
       continue;
     }
@@ -136,7 +160,7 @@ function flattenTags(tags: Tag[]) {
       flatTags.push({
         ...tag,
         tag: tagName,
-        tagEscaped: escape(tagName),
+        tagEscaped: compileTagPattern(tag, tagName),
       });
     }
   }
@@ -214,4 +238,40 @@ export function getAllTagsEscaped() {
   }
 
   return allTagsEscaped;
+}
+
+function getTagMatchers() {
+  if (!tagMatchers) {
+    tagMatchers = getConfigurationFlatten().tags.map(tag => ({
+      key: tag.tag.toLowerCase(),
+      test: new RegExp(`^(?:${tag.tagEscaped})$`, 'i'),
+    }));
+  }
+
+  return tagMatchers;
+}
+
+/**
+ * Resolve a matched tag text back to its configured decoration key.
+ *
+ * Decoration types are keyed by the configured tag string, but a wildcard/regex
+ * match captures arbitrary text (eg: `todo[FOO-123]` for tag `todo[*]`). This
+ * maps the captured text to the owning tag's key so the right decoration is
+ * applied. Matchers are tested in config order to mirror the alternation's
+ * leftmost-match preference.
+ */
+export function resolveTagKey(matched: string): string {
+  const lower = matched.toLowerCase();
+
+  for (const { key, test } of getTagMatchers()) {
+    // fast path: literal tags match their own lowercased key directly
+    if (key === lower) {
+      return key;
+    }
+    if (test.test(matched)) {
+      return key;
+    }
+  }
+
+  return lower;
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -12,13 +12,12 @@ export interface Tag {
   backgroundColor: string;
   multiline: boolean;
   /**
-   * Interpret the tag as a glob pattern (`*` = any run, `?` = any single char).
+   * Tag match mode
+   *   - text: as same as.
+   *   - wildcard: Interpret the tag as a glob pattern (`*` = any run, `?` = any single char).
+   *   - regex: Interpret the tag as a raw JavaScript regex.
    */
-  wildcard?: boolean;
-  /**
-   * Interpret the tag as a raw JavaScript regex. Takes precedence over `wildcard`.
-   */
-  regex?: boolean;
+  tagMode?: 'text' | 'wildcard' | 'regex';
 }
 
 export interface TagFlatten extends Tag {
@@ -125,17 +124,17 @@ export function getConfigurationFlatten() {
 }
 
 /**
- * Compile a tag name into a regex sub-pattern based on its matching flags.
- * Precedence: regex > wildcard > literal.
+ * Compile a tag name into a regex sub-pattern based on its match mode.
  */
 function compileTagPattern(tag: Tag, name: string): string {
-  if (tag.regex) {
-    return compileRegex(name);
+  switch (tag.tagMode) {
+    case 'regex':
+      return compileRegex(name);
+    case 'wildcard':
+      return compileGlob(name);
+    default:
+      return escape(name);
   }
-  if (tag.wildcard) {
-    return compileGlob(name);
-  }
-  return escape(name);
 }
 
 /**

--- a/src/handler/modules/common.ts
+++ b/src/handler/modules/common.ts
@@ -202,7 +202,7 @@ export class CommonHandler extends Handler {
           this.verifyTaskID(params.taskID);
 
           const m1Start = slice.start + m1.index;
-          const tagName = m1.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(m1.groups!.TAG);
 
           // exec with remember last reg index, reset m2Exp avoid reg cache
           const m2Exp = new RegExp(`(?<PRE>^|(?:${BR}?${SP}*))(?<MARK>${mark})(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gi');
@@ -269,7 +269,7 @@ export class CommonHandler extends Handler {
           const endPos = params.editor.document.positionAt(lineEnd);
           const range = new vscode.Range(startPos, endPos);
 
-          const tagName = line.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(line.groups!.TAG);
 
           const opt = params.tagRanges.get(tagName) || [];
           opt.push(range);
@@ -367,7 +367,7 @@ export class CommonHandler extends Handler {
           this.verifyTaskID(params.taskID);
 
           const m1Start = contentStart + m1.index;
-          const tagName = m1.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(m1.groups!.TAG);
           const m1Space = m1.groups!.SPACE1 || m1.groups!.SPACE2 || '';
 
           const m2Exp = /(?<PRE>(?:\r?\n|^)(?<SPACE>[ \t]*))(?<CONTENT>.*)/g;
@@ -432,7 +432,7 @@ export class CommonHandler extends Handler {
           const endPos = params.editor.document.positionAt(lineEnd);
           const range = new vscode.Range(startPos, endPos);
 
-          const tagName = line.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(line.groups!.TAG);
 
           const opt = params.tagRanges.get(tagName) || [];
           opt.push(range);
@@ -514,7 +514,7 @@ export class CommonHandler extends Handler {
           this.verifyTaskID(params.taskID);
 
           const m1Start = slice.start + slice.marks[0].length + m1.index;
-          const tagName = m1.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(m1.groups!.TAG);
 
           // exec with remember last reg index, reset m2Exp avoid reg cache
           const m2Exp = new RegExp(`(?<PRE>${BR}?${SP}*${pre}|^)(?<SPACE>${SP}*)(?<CONTENT>.*)`, 'gi');
@@ -583,7 +583,7 @@ export class CommonHandler extends Handler {
           const endPos = params.editor.document.positionAt(lineEnd);
           const range = new vscode.Range(startPos, endPos);
 
-          const tagName = line.groups!.TAG.toLowerCase();
+          const tagName = configuration.resolveTagKey(line.groups!.TAG);
 
           const opt = params.tagRanges.get(tagName) || [];
           opt.push(range);

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -15,6 +15,69 @@ export function escape(input: string): string {
   return escaped;
 }
 
+const globCache = new Map<string, string>();
+/**
+ * Compiles a glob-style tag pattern into a regex sub-pattern.
+ * `*` matches any run of characters (non-greedy), `?` matches any single
+ * character; every other character is escaped literally. The result is wrapped
+ * in a non-capturing group so it stays safe when joined with `|`.
+ * @param input The glob pattern (eg: `todo[*]`)
+ * @returns {string} The compiled regex sub-pattern
+ */
+export function compileGlob(input: string): string {
+  let compiled = globCache.get(input);
+
+  if (!compiled) {
+    // Single pass so translated wildcards are never re-processed: `*` -> any run
+    // (non-greedy), `?` -> any single char, every other metachar escaped.
+    const body = input.replace(/[*?.+^${}()|[\]\\/]/g, (m) => {
+      if (m === '*') {
+        return '.*?';
+      }
+      if (m === '?') {
+        return '.';
+      }
+      return `\\${m}`;
+    });
+    compiled = `(?:${body})`;
+    globCache.set(input, compiled);
+  }
+
+  return compiled;
+}
+
+const regexCache = new Map<string, string>();
+/**
+ * Compiles a raw JavaScript regex tag pattern into a regex sub-pattern.
+ * The pattern is validated; if it is invalid or uses a named capture group
+ * (which would collide with the PRE/TAG/CONTENT groups), it falls back to a
+ * fully-escaped literal. Valid patterns are wrapped in a non-capturing group.
+ * @param input The raw regex pattern (eg: `@\\w+`)
+ * @returns {string} The compiled regex sub-pattern
+ */
+export function compileRegex(input: string): string {
+  let compiled = regexCache.get(input);
+
+  if (!compiled) {
+    let body: string;
+    try {
+      if (input.includes('(?<')) {
+        throw new Error('named capture groups are not allowed in tag regex');
+      }
+      // eslint-disable-next-line no-new
+      new RegExp(input); // validate
+      body = input;
+    }
+    catch {
+      body = escape(input);
+    }
+    compiled = `(?:${body})`;
+    regexCache.set(input, compiled);
+  }
+
+  return compiled;
+}
+
 export const SP = '[ \\t]' as const;
 export const BR = '(?:\\r?\\n)' as const;
 export const ANY = '[\\s\\S]' as const;


### PR DESCRIPTION
## Summary

Adds two optional **per-tag** flags so a tag can match dynamically instead of as a literal string:

- `"tagMode": "wildcard"` — glob semantics: `*` matches any run of characters, `?` matches any single character; everything else is literal.
- `"tagMode": "regex"` — interpret the tag as a raw JavaScript regular expression. Named capture groups are disallowed (they collide with internal matching groups) and invalid patterns fall back to a literal match.

Tags without either flag stay literal, so the default tags (`*`, `?`, `!`, `//`, …) are **fully backward-compatible**.

### Examples

```jsonc
{
  // matches "// todo[FOO-123]: ..."
  "tag": ["todo", "to-do", "todo[*]", "todo(*)"],
  "tagMode": "wildcard",
  "color": "#FF8C00"
},
{
  // matches "// @ticket: ..."
  "tag": "@\\w+",
  "tagMode": "regex",
  "color": "#3498DB"
}
```

<img width="407" height="91" alt="image" src="https://github.com/user-attachments/assets/09be91de-8496-43ce-90ca-13a7ad43ec16" />


## Implementation

- `src/utils/regex.ts` — `compileGlob()` / `compileRegex()` compile a tag into a regex sub-pattern (wrapped in a non-capturing group so the existing `tags.join('|')` assembly stays safe). Glob translation is single-pass to avoid re-processing inserted metacharacters.
- `src/configuration/configuration.ts` — `tagMode` key on `Tag`, `compileTagPattern()` selects the compiler (defaults to literal), and a new `resolveTagKey()` maps a matched string back to its configured decoration key.
- `src/handler/modules/common.ts` — the 6 line/block/doc keying sites now resolve via `resolveTagKey()` instead of using the raw matched text (a wildcard match captures e.g. `todo[FOO-123]`, which no longer equals the configured key `todo[*]`).
- `package.json` — `tagMode` property documented in the tag schema.
- `README.md` — new "TagMode tag" section.

## Testing

`tsc --noEmit`, `eslint --max-warnings 0`, and both (`node` + `web`) `tsup` builds pass.
Limited manual testing in VS Code and Cursor
